### PR TITLE
[AKS] Add --enable-control-plane-metrics and --disable-control-plane-metrics for Managed Prometheus

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -534,6 +534,12 @@ parameters:
   - name: --enable-windows-recording-rules
     type: bool
     short-summary: Enable Windows Recording Rules when enabling the Azure Monitor Metrics addon
+  - name: --enable-control-plane-metrics
+    type: bool
+    short-summary: Enable collection of control plane metrics for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for details. Must be used with --enable-azure-monitor-metrics.
+  - name: --disable-control-plane-metrics
+    type: bool
+    short-summary: Disable collection of control plane metrics for the Azure Managed Prometheus addon.
   - name: --nodepool-taints
     type: string
     short-summary: The node taints for all node pool.
@@ -1063,6 +1069,12 @@ parameters:
   - name: --disable-azure-monitor-metrics
     type: bool
     short-summary: Disable Azure Monitor Metrics Profile. This will delete all DCRA's associated with the cluster, any linked DCRs with the data stream = prometheus-stream and the recording rule groups created by the addon for this AKS cluster.
+  - name: --enable-control-plane-metrics
+    type: bool
+    short-summary: Enable collection of control plane metrics for the Azure Managed Prometheus addon. Configures collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc). See aka.ms/aks/controlplane-metrics for details.
+  - name: --disable-control-plane-metrics
+    type: bool
+    short-summary: Disable collection of control plane metrics for the Azure Managed Prometheus addon.
   - name: --nodepool-taints
     type: string
     short-summary: The node taints for all node pool.

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -568,6 +568,8 @@ def load_arguments(self, _):
         c.argument('ksm_metric_annotations_allow_list')
         c.argument('grafana_resource_id', validator=validate_grafanaresourceid)
         c.argument('enable_windows_recording_rules', action='store_true')
+        c.argument('enable_control_plane_metrics', action='store_true')
+        c.argument('disable_control_plane_metrics', action='store_true')
         c.argument('node_public_ip_tags', arg_type=tags_type, validator=validate_node_public_ip_tags,
                    help='space-separated tags: key[=value] [key[=value] ...].')
         # azure container storage
@@ -795,6 +797,8 @@ def load_arguments(self, _):
         c.argument('grafana_resource_id', validator=validate_grafanaresourceid)
         c.argument('enable_windows_recording_rules', action='store_true')
         c.argument('disable_azure_monitor_metrics', action='store_true')
+        c.argument('enable_control_plane_metrics', action='store_true')
+        c.argument('disable_control_plane_metrics', action='store_true')
         # azure container storage
         c.argument(
             "enable_azure_container_storage",

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1008,6 +1008,8 @@ def aks_create(
     ksm_metric_annotations_allow_list=None,
     grafana_resource_id=None,
     enable_windows_recording_rules=False,
+    enable_control_plane_metrics=False,
+    disable_control_plane_metrics=False,
     # azure container storage
     enable_azure_container_storage=None,
     container_storage_version=None,
@@ -1200,6 +1202,8 @@ def aks_update(
     grafana_resource_id=None,
     enable_windows_recording_rules=False,
     disable_azure_monitor_metrics=False,
+    enable_control_plane_metrics=False,
+    disable_control_plane_metrics=False,
     # azure container storage
     enable_azure_container_storage=None,
     disable_azure_container_storage=None,

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -5762,6 +5762,91 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         return self._get_disable_azure_monitor_metrics(enable_validation=True)
 
+    def _get_enable_control_plane_metrics(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of enable_control_plane_metrics.
+
+        :return: bool
+        """
+        enable_control_plane_metrics = self.raw_param.get("enable_control_plane_metrics")
+        if enable_validation:
+            if enable_control_plane_metrics and self._get_disable_control_plane_metrics(False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-control-plane-metrics and "
+                    "--disable-control-plane-metrics at the same time"
+                )
+            if enable_control_plane_metrics:
+                # In create mode, --enable-azure-monitor-metrics must be specified
+                if self.decorator_mode == DecoratorMode.CREATE:
+                    if not self._get_enable_azure_monitor_metrics(False):
+                        raise RequiredArgumentMissingError(
+                            "--enable-control-plane-metrics cannot be used as a standalone flag. "
+                            "This flag must be used in conjunction with --enable-azure-monitor-metrics "
+                            "to enable control plane metrics collection. "
+                            "Usage: az aks create --enable-azure-monitor-metrics --name <cluster-name> "
+                            "--resource-group <cluster-resource-group> --enable-control-plane-metrics"
+                        )
+                # In update mode, azure monitor metrics must already be enabled on the cluster or being enabled now
+                if self.decorator_mode == DecoratorMode.UPDATE:
+                    is_metrics_enabled = (
+                        self.mc and
+                        hasattr(self.mc, "azure_monitor_profile") and
+                        self.mc.azure_monitor_profile and
+                        self.mc.azure_monitor_profile.metrics and
+                        getattr(self.mc.azure_monitor_profile.metrics, "enabled", False)
+                    )
+                    if not self._get_enable_azure_monitor_metrics(False) and not is_metrics_enabled:
+                        raise RequiredArgumentMissingError(
+                            "--enable-control-plane-metrics cannot be used as a standalone flag. "
+                            "This flag must be used in conjunction with --enable-azure-monitor-metrics "
+                            "to enable control plane metrics collection, or Azure Monitor Metrics must "
+                            "already be enabled on the cluster. "
+                            "Usage: az aks update --enable-azure-monitor-metrics --name <cluster-name> "
+                            "--resource-group <cluster-resource-group> --enable-control-plane-metrics"
+                        )
+        return enable_control_plane_metrics
+
+    def get_enable_control_plane_metrics(self) -> bool:
+        """Obtain the value of enable_control_plane_metrics.
+
+        :return: bool
+        """
+        return self._get_enable_control_plane_metrics(enable_validation=True)
+
+    def _get_disable_control_plane_metrics(self, enable_validation: bool = False) -> bool:
+        """Internal function to obtain the value of disable_control_plane_metrics.
+
+        :return: bool
+        """
+        disable_control_plane_metrics = self.raw_param.get("disable_control_plane_metrics")
+        if enable_validation:
+            if disable_control_plane_metrics and self._get_enable_control_plane_metrics(False):
+                raise MutuallyExclusiveArgumentError(
+                    "Cannot specify --enable-control-plane-metrics and "
+                    "--disable-control-plane-metrics at the same time"
+                )
+            if disable_control_plane_metrics:
+                # Control plane metrics can only be disabled if azure monitor metrics is enabled
+                is_metrics_enabled = (
+                    self.mc and
+                    hasattr(self.mc, "azure_monitor_profile") and
+                    self.mc.azure_monitor_profile and
+                    self.mc.azure_monitor_profile.metrics and
+                    getattr(self.mc.azure_monitor_profile.metrics, "enabled", False)
+                )
+                if not self._get_enable_azure_monitor_metrics(False) and not is_metrics_enabled:
+                    raise RequiredArgumentMissingError(
+                        "--disable-control-plane-metrics requires Azure Monitor Metrics to be enabled "
+                        "on the cluster. Enable it first with --enable-azure-monitor-metrics."
+                    )
+        return disable_control_plane_metrics
+
+    def get_disable_control_plane_metrics(self) -> bool:
+        """Obtain the value of disable_control_plane_metrics.
+
+        :return: bool
+        """
+        return self._get_disable_control_plane_metrics(enable_validation=True)
+
     def _get_enable_vpa(self, enable_validation: bool = False) -> bool:
         """Internal function to obtain the value of enable_vpa.
         This function supports the option of enable_vpa. When enabled, if both enable_vpa and enable_vpa are
@@ -7328,6 +7413,13 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
             mc.azure_monitor_profile.metrics.kube_state_metrics = self.models.ManagedClusterAzureMonitorProfileKubeStateMetrics(  # pylint:disable=line-too-long
                 metric_labels_allowlist=str(ksm_metric_labels_allow_list),
                 metric_annotations_allow_list=str(ksm_metric_annotations_allow_list))
+            # set up control plane metrics if requested
+            enable_control_plane_metrics = self.context.raw_param.get("enable_control_plane_metrics")
+            disable_control_plane_metrics = self.context.raw_param.get("disable_control_plane_metrics")
+            if enable_control_plane_metrics:
+                mc.azure_monitor_profile.metrics.control_plane = self.models.ManagedClusterAzureMonitorProfileMetricsControlPlane(enabled=True)  # pylint:disable=line-too-long
+            elif disable_control_plane_metrics:
+                mc.azure_monitor_profile.metrics.control_plane = self.models.ManagedClusterAzureMonitorProfileMetricsControlPlane(enabled=False)  # pylint:disable=line-too-long
             # set intermediate
             self.context.set_intermediate("azuremonitormetrics_addon_enabled", True, overwrite_exists=True)
         return mc
@@ -9268,6 +9360,17 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
             if mc.azure_monitor_profile is None:
                 mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
             mc.azure_monitor_profile.metrics = self.models.ManagedClusterAzureMonitorProfileMetrics(enabled=False)
+
+        # handle control plane metrics enable/disable independently
+        enable_control_plane_metrics = self.context.get_enable_control_plane_metrics()
+        disable_control_plane_metrics = self.context.get_disable_control_plane_metrics()
+        if enable_control_plane_metrics or disable_control_plane_metrics:
+            if mc.azure_monitor_profile is None:
+                mc.azure_monitor_profile = self.models.ManagedClusterAzureMonitorProfile()
+            if mc.azure_monitor_profile.metrics is None:
+                mc.azure_monitor_profile.metrics = self.models.ManagedClusterAzureMonitorProfileMetrics(enabled=True)
+            mc.azure_monitor_profile.metrics.control_plane = self.models.ManagedClusterAzureMonitorProfileMetricsControlPlane(  # pylint:disable=line-too-long
+                enabled=bool(enable_control_plane_metrics))
 
         if (
             self.context.raw_param.get("enable_azure_monitor_metrics") or


### PR DESCRIPTION
## Description

Add CLI support for the new **Control Plane Metrics** feature in the Azure Managed Prometheus addon. This enables collection of operational runtime metrics from managed control plane components (kube-apiserver, etcd, etc.) via the `ManagedClusterAzureMonitorProfileMetricsControlPlane` model.

### Background

- **API Spec PR**: https://github.com/Azure/azure-rest-api-specs/pull/41280 (merged March 12, 2026)
- **API Version**: `2026-02-02-preview`
- **Feature Docs**: https://aka.ms/aks/controlplane-metrics

This is part of the CCP Metrics GA plan. The feature transitions from a preview feature-flag-based enablement to an explicit opt-in via a new `controlPlane` property on the `ManagedClusterAzureMonitorProfileMetrics` model.

### New CLI Parameters

| Parameter | Command | Type | Description |
|-----------|---------|------|-------------|
| `--enable-control-plane-metrics` | `az aks create` | bool | Enable control plane metrics when creating a cluster with `--enable-azure-monitor-metrics` |
| `--disable-control-plane-metrics` | `az aks create` | bool | Explicitly disable control plane metrics at create time |
| `--enable-control-plane-metrics` | `az aks update` | bool | Enable control plane metrics on an existing cluster (requires Azure Monitor Metrics to be enabled) |
| `--disable-control-plane-metrics` | `az aks update` | bool | Disable control plane metrics on an existing cluster |

### CLI Usage Examples

**Enable on new cluster:**
```
az aks create --enable-azure-monitor-metrics \
  --name <cluster-name> \
  --resource-group <resource-group> \
  --enable-control-plane-metrics
```

**Enable on existing cluster (metrics already enabled):**
```
az aks update --name <cluster-name> \
  --resource-group <resource-group> \
  --enable-control-plane-metrics
```

**Enable both monitor metrics and control plane on existing cluster:**
```
az aks update --enable-azure-monitor-metrics \
  --name <cluster-name> \
  --resource-group <resource-group> \
  --enable-control-plane-metrics
```

**Disable control plane metrics:**
```
az aks update --name <cluster-name> \
  --resource-group <resource-group> \
  --disable-control-plane-metrics
```

### Validation Rules

1. **Cannot use standalone**: `--enable-control-plane-metrics` cannot be used without `--enable-azure-monitor-metrics` on create, or without Azure Monitor Metrics already being enabled on the cluster for update. Error:
   > `--enable-control-plane-metrics cannot be used as a standalone flag. This flag must be used in conjunction with --enable-azure-monitor-metrics to enable control plane metrics collection.`

2. **Mutual exclusivity**: `--enable-control-plane-metrics` and `--disable-control-plane-metrics` cannot be specified together.

3. **Disable requires metrics**: `--disable-control-plane-metrics` requires Azure Monitor Metrics to be enabled on the cluster.

### ARM Model Shape

```json
{
  "azureMonitorProfile": {
    "metrics": {
      "enabled": true,
      "controlPlane": {
        "enabled": true
      },
      "kubeStateMetrics": { }
    }
  }
}
```

### Files Changed

| File | Changes |
|------|---------|
| `_params.py` | Added `enable_control_plane_metrics` and `disable_control_plane_metrics` to both create and update command groups |
| `custom.py` | Added new parameters to `aks_create()` and `aks_update()` function signatures |
| `managed_cluster_decorator.py` | Added getter/validator methods with validation (mutual exclusivity, requires monitor metrics). Updated `set_up_azure_monitor_profile` (create) and `update_azure_monitor_profile` (update) to set `control_plane` on the metrics object |
| `_help.py` | Added help text for all new parameters in both create and update commands |

### Customer Scenarios Covered

| # | Scenario | Behavior |
|---|----------|----------|
| 1 | New cluster with control plane metrics | `az aks create --enable-azure-monitor-metrics --enable-control-plane-metrics` enables API Server and ETCD metrics |
| 2 | Existing cluster, add control plane metrics | `az aks update --enable-control-plane-metrics` (if monitor metrics already enabled) |
| 3 | Preview to GA transition | Existing preview customers backfilled via regional looper; `controlPlane.enabled=true` set automatically |
| 4 | Without monitor metrics addon | `az aks create --enable-control-plane-metrics` alone gives error with guidance to enable monitor metrics first |
| 5 | Disable control plane metrics | `az aks update --disable-control-plane-metrics` stops collection while keeping monitor metrics enabled |

### Known Blockers

> **SDK dependency**: `ManagedClusterAzureMonitorProfileMetricsControlPlane` does not yet exist in `azure-mgmt-containerservice`. Current pin is `41.0.0` and latest beta `41.1.0b1` also does not include it. This PR is ready for review but **cannot be merged or tested end-to-end until the SDK is updated**.

### TODO (post SDK availability)

- [ ] Bump `azure-mgmt-containerservice` version in `setup.py`
- [ ] Add unit tests in `test_managed_cluster_decorator.py`
- [ ] Add integration test recordings
- [ ] Verify end-to-end with a live cluster

### Related

- API Spec PR: https://github.com/Azure/azure-rest-api-specs/pull/41280
- Last SDK bump PR: https://github.com/Azure/azure-cli/pull/32955
